### PR TITLE
Bugs fixed:

### DIFF
--- a/main.pyw
+++ b/main.pyw
@@ -3,6 +3,7 @@
 
 import dotenv # for email and password
 import wx
+from threading import Thread
 from guinput import GUInput, ChooseFromList, AuthInput
 from datetime import datetime
 from calendar import isleap
@@ -39,9 +40,8 @@ class MainWindow(wx.Frame):
         # command checker runs over and over again by wx timer
         self.timer = wx.Timer(self)
         self.Bind(wx.EVT_TIMER, self.reply_checker, self.timer)
-        self.timer.Start(10) # run the reply checker every 10 ms
-
-
+        self.timer.Start(milliseconds = 750, oneShot = True)  # run the reply checker every 750 ms
+        print("timer started")
 
     def custom_date_picker(self):
         # the default date picker is not screen reader friendly. We make a custom that allows to tab navigate through the window.
@@ -127,6 +127,7 @@ class MainWindow(wx.Frame):
 
     def OnSaveToTxt(self, event):
         # save to schedule.txt
+        event.Skip()
         with open("schedule.txt", "w") as f:
             f.write(self.control.GetValue())
         self.SetStatusText("Расписание сохранено в schedule.txt")
@@ -134,6 +135,7 @@ class MainWindow(wx.Frame):
 
     def OnDateChanged(self, event):
         # get the schedule
+        event.Skip()
         if self.authed:
             self.schedule()
         event.Skip()
@@ -150,7 +152,8 @@ class MainWindow(wx.Frame):
         self.app.send_command(["schedule", date, None, None]) # end date and overlap are None
         # that's all. This function ends here. The schedule will be displayed in the control when the app thread finishes the command.
 
-    def reply_checker(self, *args): # now commands are tuples, so we can use tuple match command[0]
+    def reply_checker(self, event, *args): # now commands are tuples, so we can use tuple match command[0]
+        event.Skip()
         # if i will get headaches from this, the credential checker will return quickly and if it is not authed, it will ask for credentials again.
         if not self.app.has_reply:
             return
@@ -228,7 +231,8 @@ class MainWindow(wx.Frame):
         if exit:
             self.exit()
 
-    def exit(self, event=None):  # we don't need the event
+    def exit(self, event=None):
+        if event: event.Skip()
         self.SetStatusText("Выход...")
         self.SetTitle("Выход...")
         self.app.send_command(["exit"])

--- a/schedule.py
+++ b/schedule.py
@@ -253,7 +253,7 @@ class Schedule:
         if overlap_id !="" and overlap_id is not None:
             self.last_msg = f"Общее расписания пользователя {self.get_person_by_id(person_id)['name']} и {self.get_person_by_id(overlap_id)['name']}:\n"
         else:
-            self.last_msg=f"Расписание пользователя {self.get_person_by_id(person_id)["name"]}:\n"
+            self.last_msg=f"Расписание пользователя {self.get_person_by_id(person_id)['name']}:\n"
         self.last_msg+=schedparser.humanize_events(self.schedule(person_id, start_time, end_time, overlap_id))
         return self.last_msg
 


### PR DESCRIPTION
1. I don't have Python 3.12, but 3.10, so I fixed the quotes in the f line;
2. There is no need to destroy dialog boxes, the framework will do everything itself, on the contrary, you need to give the Skip command and allow it to close in the usual way.
3. `event.Skip()` must always be called. Imagine a hook to the keyboard or mouse, you intercepted it, did something, but did not transmit it back to the system. And your computer froze.
4. The timer has a one shot parameter; until one event is completed, it will not take others, otherwise it will freeze. The program did not have time to process one event, then another. And so on endlessly.